### PR TITLE
WebKitSnapshotRegion implemented

### DIFF
--- a/webkit2/webview.go
+++ b/webkit2/webview.go
@@ -256,7 +256,7 @@ func (v *WebView) GetSnapshot(snapshotRegion SnapshotRegion, resultCallback func
 	}
 
 	C.webkit_web_view_get_snapshot(v.webView,
-		(C.WebKitSnapshotRegion)(snapshotRegion), // FullDocument is the only working region at this point
+		(C.WebKitSnapshotRegion)(snapshotRegion),
 		(C.WebKitSnapshotOptions)(0),
 		nil,
 		cCallback,

--- a/webkit2/webview.go
+++ b/webkit2/webview.go
@@ -192,7 +192,10 @@ func (v *WebView) GetSnapshot(resultCallback func(result *image.RGBA, err error)
 			var snapErr *C.GError
 			snapResult := C.webkit_web_view_get_snapshot_finish(v.webView, result, &snapErr)
 			if snapResult == nil {
+
+
 				defer C.g_error_free(snapErr)
+
 				msg := C.GoString((*C.char)(snapErr.message))
 				resultCallback(nil, errors.New(msg))
 				return
@@ -242,7 +245,7 @@ func (v *WebView) GetSnapshot(resultCallback func(result *image.RGBA, err error)
 	}
 
 	C.webkit_web_view_get_snapshot(v.webView,
-		(C.WebKitSnapshotRegion)(1), // FullDocument is the only working region at this point
+		(C.WebKitSnapshotRegion)(0), // FullDocument is the only working region at this point
 		(C.WebKitSnapshotOptions)(0),
 		nil,
 		cCallback,

--- a/webkit2/webview.go
+++ b/webkit2/webview.go
@@ -170,6 +170,20 @@ const (
 	LoadFinished
 )
 
+// SnapshotRegion specify the region from which to get a WebView snapshot
+//
+// See also: WebKitSnapshotRegion at
+// http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#WebKitSnapshotRegion.
+type SnapshotRegion int
+
+// SnapshotRegion enum values are described at
+// http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#WebKitSnapshotRegion.
+const (
+	SnapshotRegionVisible SnapshotRegion = iota
+	SnapshotRegionFullDocument
+)
+
+
 // http://cairographics.org/manual/cairo-cairo-surface-t.html#cairo-surface-type-t
 const cairoSurfaceTypeImage = 0
 
@@ -183,7 +197,7 @@ const cairoImageSurfaceFormatARGB32 = 0
 //
 // See also: webkit_web_view_get_snapshot at
 // http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#webkit-web-view-get-snapshot
-func (v *WebView) GetSnapshot(resultCallback func(result *image.RGBA, err error)) {
+func (v *WebView) GetSnapshot(loadEvent LoadEvent ,resultCallback func(result *image.RGBA, err error)) {
 	var cCallback C.GAsyncReadyCallback
 	var userData C.gpointer
 	var err error
@@ -245,7 +259,7 @@ func (v *WebView) GetSnapshot(resultCallback func(result *image.RGBA, err error)
 	}
 
 	C.webkit_web_view_get_snapshot(v.webView,
-		(C.WebKitSnapshotRegion)(0), // FullDocument is the only working region at this point
+		(C.WebKitSnapshotRegion)(loadEvent), // FullDocument is the only working region at this point
 		(C.WebKitSnapshotOptions)(0),
 		nil,
 		cCallback,

--- a/webkit2/webview.go
+++ b/webkit2/webview.go
@@ -197,7 +197,7 @@ const cairoImageSurfaceFormatARGB32 = 0
 //
 // See also: webkit_web_view_get_snapshot at
 // http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#webkit-web-view-get-snapshot
-func (v *WebView) GetSnapshot(snapshotRegion SnapshotRegion ,resultCallback func(result *image.RGBA, err error)) {
+func (v *WebView) GetSnapshot(snapshotRegion SnapshotRegion, resultCallback func(result *image.RGBA, err error)) {
 	var cCallback C.GAsyncReadyCallback
 	var userData C.gpointer
 	var err error
@@ -206,10 +206,7 @@ func (v *WebView) GetSnapshot(snapshotRegion SnapshotRegion ,resultCallback func
 			var snapErr *C.GError
 			snapResult := C.webkit_web_view_get_snapshot_finish(v.webView, result, &snapErr)
 			if snapResult == nil {
-
-
 				defer C.g_error_free(snapErr)
-
 				msg := C.GoString((*C.char)(snapErr.message))
 				resultCallback(nil, errors.New(msg))
 				return

--- a/webkit2/webview.go
+++ b/webkit2/webview.go
@@ -197,7 +197,7 @@ const cairoImageSurfaceFormatARGB32 = 0
 //
 // See also: webkit_web_view_get_snapshot at
 // http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#webkit-web-view-get-snapshot
-func (v *WebView) GetSnapshot(loadEvent LoadEvent ,resultCallback func(result *image.RGBA, err error)) {
+func (v *WebView) GetSnapshot(snapshotRegion SnapshotRegion ,resultCallback func(result *image.RGBA, err error)) {
 	var cCallback C.GAsyncReadyCallback
 	var userData C.gpointer
 	var err error
@@ -259,7 +259,7 @@ func (v *WebView) GetSnapshot(loadEvent LoadEvent ,resultCallback func(result *i
 	}
 
 	C.webkit_web_view_get_snapshot(v.webView,
-		(C.WebKitSnapshotRegion)(loadEvent), // FullDocument is the only working region at this point
+		(C.WebKitSnapshotRegion)(snapshotRegion), // FullDocument is the only working region at this point
 		(C.WebKitSnapshotOptions)(0),
 		nil,
 		cCallback,

--- a/webkit2/webview_test.go
+++ b/webkit2/webview_test.go
@@ -264,7 +264,7 @@ func TestWebView_GetSnapshot(t *testing.T) {
 	webView.Connect("load-changed", func(_ *glib.Object, loadEvent LoadEvent) {
 		switch loadEvent {
 		case LoadFinished:
-			webView.GetSnapshot(func(img *image.RGBA, err error) {
+			webView.GetSnapshot(SnapshotRegionVisible, func(img *image.RGBA, err error) {
 				if err != nil {
 					t.Errorf("GetSnapshot error: %q", err)
 				}


### PR DESCRIPTION
This closes https://github.com/sourcegraph/go-webkit2/issues/10

when rendering the go-webkit widget in a gtk window this feature should work. go-webkit should be rendered within a GTK window in most cases anyways and this should be noted in our docs/examples.

http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#WebKitSnapshotRegion