### PR TITLE
Bump major version to webkit2gtk-4

### DIFF
--- a/webkit2/webview.go
+++ b/webkit2/webview.go
@@ -6,7 +6,7 @@ package webkit2
 //
 // static WebKitWebView* to_WebKitWebView(GtkWidget* w) { return WEBKIT_WEB_VIEW(w); }
 //
-// #cgo pkg-config: webkit2gtk-3.0
+// #cgo pkg-config: webkit2gtk-4.0
 import "C"
 
 import (


### PR DESCRIPTION
New relevent Debian and Ubuntu packages will be:

libwebkit2gtk-4.0-dev
libwebkit2gtk-4.0-* (currently libwebkit2gtk-4.0-37)