### PR TITLE
Memory managed by Go can't be passed to C as of Go 1.6

### DIFF
--- a/webkit2/gasyncreadycallback.go
+++ b/webkit2/gasyncreadycallback.go
@@ -25,6 +25,8 @@ func newGAsyncReadyCallback(f interface{}) (cCallback C.GAsyncReadyCallback, use
 	if rf.Kind() != reflect.Func {
 		return nil, nil, errors.New("f is not a function")
 	}
-	cbinfo := &garCallback{rf}
+	data := C.malloc(C.size_t(unsafe.Sizeof(garCallback{})))
+	cbinfo := (*garCallback)(data)
+	cbinfo.f = rf
 	return C.GAsyncReadyCallback(C._gasyncreadycallback_call), C.gpointer(unsafe.Pointer(cbinfo)), nil
 }

--- a/webkit2/webview.go
+++ b/webkit2/webview.go
@@ -125,6 +125,7 @@ func (v *WebView) RunJavaScript(script string, resultCallback func(result *gojs.
 	var err error
 	if resultCallback != nil {
 		callback := func(result *C.GAsyncResult) {
+			C.free(unsafe.Pointer(userData))
 			var jserr *C.GError
 			jsResult := C.webkit_web_view_run_javascript_finish(v.webView, result, &jserr)
 			if jsResult == nil {
@@ -189,6 +190,7 @@ func (v *WebView) GetSnapshot(resultCallback func(result *image.RGBA, err error)
 	var err error
 	if resultCallback != nil {
 		callback := func(result *C.GAsyncResult) {
+			C.free(unsafe.Pointer(userData))
 			var snapErr *C.GError
 			snapResult := C.webkit_web_view_get_snapshot_finish(v.webView, result, &snapErr)
 			if snapResult == nil {


### PR DESCRIPTION
Discussion at:

    https://github.com/golang/go/issues/12416
    https://github.com/golang/proposal/blob/master/design/12416-cgo-pointers.md

Issues with the Go memory management code were hacked around by adding a
new check that ensured that pointers to memory managed by Go are never
passed to cgo code, since one can not be sure how and where pointers to
Go memory are being stored in the C code.

As a result, the memory must be manually malloc'd and free'd by cgo,
even if it's a Go object in the C memory. The userdata fix makes this
change explicit, by running a malloc and free using cgo, to explicitly
control the memory management.