### PR TITLE
Replace google.com with the github system status

### DIFF
--- a/webkit2/example_test.go
+++ b/webkit2/example_test.go
@@ -39,7 +39,7 @@ func Example() {
 	})
 
 	glib.IdleAdd(func() bool {
-		webView.LoadURI("https://www.google.com/")
+		webView.LoadURI("https://status.github.com/")
 		return false
 	})
 
@@ -47,7 +47,7 @@ func Example() {
 
 	// output:
 	// Load finished.
-	// Title: "Google"
-	// URI: https://www.google.com/
-	// Hostname (from JavaScript): "www.google.com"
+	// Title: "GitHub System Status"
+	// URI: https://status.github.com/
+	// Hostname (from JavaScript): "status.github.com"
 }


### PR DESCRIPTION
Due to local redirects the example output messes up unit tests,
as the output is e.g. google.de and not google.com.
This commit replaces google with a page that does not do localized redirects
and is unlikely to change the title.
Fixes sourcegraph#38